### PR TITLE
Fix: Add installation warnings to prevent app bundle issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,15 @@ xattr -d com.apple.quarantine /Applications/Transcriber.app
 - Click "Open" when macOS warns about unidentified developer
 - The app will then launch normally in future
 
+### ⚠️ Important Installation Notes
+
+**Always use the proper app bundle**: The app must be installed as `Transcriber.app` (an app bundle) in `/Applications/`, not as a raw executable file.
+
+- ✅ **Correct**: `/Applications/Transcriber.app/` 
+- ❌ **Incorrect**: `/Applications/transcriber` (raw executable)
+
+If you accidentally install a raw executable file, it will open as a text document instead of launching the application. Use the DMG installer to ensure proper installation.
+
 ### Build from Source
 
 ```bash


### PR DESCRIPTION
## Summary

Adds clear documentation warnings to prevent the installation issue where users accidentally install raw executables instead of proper app bundles, causing the app to open as a text document.

## Problem Solved

- Users were installing raw `TranscriberApp` executable as `/Applications/transcriber`
- This caused macOS to treat it as a text document instead of launching the application
- The issue occurred because installation instructions weren't explicit enough about app bundle requirements

## Changes Made

- ✅ Added clear warning section about proper app bundle installation
- ✅ Documented the difference between correct (`.app` bundle) and incorrect (raw executable) installation
- ✅ Added specific examples of correct vs incorrect installation paths
- ✅ Emphasized using the DMG installer for proper installation

## Prevention

This documentation update will help prevent future users from experiencing the same installation confusion that led to raw executables being placed in incorrect locations.

## Testing

- [x] Verified documentation is clear and helpful
- [x] Confirmed DMG installer creates proper app bundle structure
- [x] Tested that proper installation works correctly

Closes #62